### PR TITLE
feat: soft-fail messaging with auto-detection (closes #60, #59)

### DIFF
--- a/contracts/dao/extensions/aibtc-onchain-messaging-v2.clar
+++ b/contracts/dao/extensions/aibtc-onchain-messaging-v2.clar
@@ -1,0 +1,74 @@
+;; title: aibtc-onchain-messaging-v2
+;; version: 2.0.0
+;; summary: An extension to send messages on-chain with soft-fail verification.
+;;          Automatically detects if sender is DAO, token holder, or unverified.
+
+;; traits
+;;
+(impl-trait .aibtc-dao-traits-v4.extension)
+(impl-trait .aibtc-dao-traits-v4.messaging)
+
+;; constants
+;;
+(define-constant ERR_INVALID_INPUT (err u4000))
+
+;; public functions
+
+(define-public (callback (sender principal) (memo (buff 34)))
+  (ok true)
+)
+
+(define-public (send (msg (string-ascii 1048576)))
+  (let
+    (
+      ;; Soft-fail checks: determine sender type without failing transaction
+      (isFromDao (check-is-dao-or-extension))
+      (isFromHolder (and (not isFromDao) (check-is-token-holder)))
+    )
+    (asserts! (> (len msg) u0) ERR_INVALID_INPUT)
+    ;; print the message as the first event
+    (print msg)
+    ;; print the envelope info for the message with verified sender flags
+    (print {
+      notification: "send",
+      payload: {
+        contractCaller: contract-caller,
+        height: stacks-block-height,
+        isFromDao: isFromDao,
+        isFromHolder: isFromHolder,
+        txSender: tx-sender,
+        messageLength: (len msg)
+      }
+    })
+    (ok true)
+  )
+)
+
+;; private functions
+;;
+
+;; Soft-fail check: returns true if sender is DAO or extension, false otherwise
+(define-private (check-is-dao-or-extension)
+  (or
+    (is-eq tx-sender .aibtc-base-dao)
+    (contract-call? .aibtc-base-dao is-extension contract-caller)
+  )
+)
+
+;; Soft-fail check: returns true if sender holds DAO tokens, false otherwise
+;; Returns false if balance check fails (conservative approach)
+(define-private (check-is-token-holder)
+  (> (get-token-balance tx-sender) u0)
+)
+
+;; Helper to get token balance with error handling
+;; Returns 0 if the contract call fails
+(define-private (get-token-balance (account principal))
+  (default-to u0
+    (unwrap-panic
+      (ok
+        (unwrap! (contract-call? .aibtc-token get-balance account) u0)
+      )
+    )
+  )
+)

--- a/contracts/dao/traits/aibtc-dao-traits-v4.clar
+++ b/contracts/dao/traits/aibtc-dao-traits-v4.clar
@@ -1,0 +1,253 @@
+;; title: aibtc-dao-traits
+;; version: 4.0.0
+;; summary: A collection of traits for all aibtc daos.
+
+;; IMPORTS
+(use-trait faktory-token .faktory-trait-v1.sip-010-trait)
+(use-trait ft-trait 'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard.sip-010-trait)
+(use-trait nft-trait 'SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.nft-trait.nft-trait)
+
+;; CORE DAO TRAITS
+
+;; a one-time action proposed by token holders
+(define-trait proposal (
+  (execute (principal) (response bool uint))
+))
+
+;; a standing feature of the dao implemented in Clarity
+(define-trait extension (
+  (callback (principal (buff 34)) (response bool uint))
+))
+
+;; TOKEN TRAITS
+
+;; the decentralized Bitflow trading pool following their xyk formula
+(define-trait bitflow-pool (
+  ;; transfer funds (we're just tagging this contract)
+  ;; all functions are covered between sip-010 and bitflow-xyk
+  (transfer (uint principal principal (optional (buff 34))) (response bool uint))
+))
+
+;; the decentralized exchange and initial bonding curve for a token
+;; can be used to buy and sell tokens until the target is reached
+;; liquidity is provided by the initial minting of tokens (20%)
+;; reaching the target will trigger migration to the Bitflow pool
+(define-trait faktory-dex (
+  ;; buy tokens from the dex
+  ;; @param ft the token contract
+  ;; @param ustx the amount of microSTX to spend
+  ;; @returns (response bool uint)
+  (buy (<faktory-token> uint) (response bool uint))
+  ;; sell tokens to the dex
+  ;; @param ft the token contract
+  ;; @param amount the amount of tokens to sell
+  ;; @returns (response bool uint)
+  (sell (<faktory-token> uint) (response bool uint))
+))
+
+;; the token contract for the dao, with no pre-mine or initial allocation
+(define-trait token (
+  ;; transfer funds (limited as we're just tagging this)
+  (transfer (uint principal principal (optional (buff 34))) (response bool uint))
+))
+
+;; EXTENSION TRAITS
+
+;; a pre-defined action that token holders can propose
+(define-trait action (
+  ;; @param parameters serialized hex-encoded Clarity values
+  ;; @returns (response bool uint)
+  (run ((buff 2048)) (response bool uint))
+))
+
+;; a voting contract for whitelisted pre-defined actions
+;; has lower voting threshold and quorum than core proposals
+(define-trait action-proposals (
+  ;; propose a new action
+  ;; @param action the action contract
+  ;; @param parameters encoded action parameters
+  ;; @returns (response bool uint)
+  (propose-action (<action> (buff 2048) (optional (string-ascii 1024))) (response bool uint))
+  ;; vote on an existing proposal
+  ;; @param proposal the proposal id
+  ;; @param vote true for yes, false for no
+  ;; @returns (response bool uint)
+  (vote-on-proposal (uint bool) (response bool uint))
+  ;; conclude a proposal after voting period
+  ;; @param proposal the proposal id
+  ;; @param action the action contract
+  ;; @returns (response bool uint)
+  (conclude-proposal (uint <action>) (response bool uint))
+))
+
+;; a smart contract that can be funded and assigned to a principal
+;; withdrawals are based on a set amount and time period in blocks
+(define-trait timed-vault (
+  ;; set account holder
+  ;; @param principal the new account holder who can withdraw
+  ;; @returns (response bool uint)
+  (set-account-holder (principal) (response bool uint))
+  ;; set withdrawal period
+  ;; @param period the new withdrawal period in Bitcoin blocks
+  ;; @returns (response bool uint)
+  (set-withdrawal-period (uint) (response bool uint))
+  ;; set withdrawal amount
+  ;; @param amount the new withdrawal amount in micro-units
+  ;; @returns (response bool uint)
+  (set-withdrawal-amount (uint) (response bool uint))
+  ;; override last withdrawal block
+  ;; @param block the new last withdrawal block
+  ;; @returns (response bool uint)
+  (override-last-withdrawal-block (uint) (response bool uint))
+  ;; deposit funds to the timed vault
+  ;; @param amount amount of token to deposit in micro-units
+  ;; @returns (response bool uint)
+  (deposit (uint) (response bool uint))
+  ;; withdraw funds from the timed vault
+  ;; @returns (response bool uint) 
+  (withdraw () (response bool uint))
+))
+
+;; an extension to manage the dao charter and mission
+;; allows the dao to define its mission and values on-chain
+;; used to guide decision-making and proposals
+(define-trait charter (
+  ;; set the dao charter
+  ;; @param charter the new charter text
+  ;; @returns (response bool uint)
+  (set-dao-charter ((string-ascii 4096) (optional (buff 33))) (response bool uint))
+))
+
+;; a voting contract for core dao proposals
+;; has higher voting threshold and quorum than action proposals
+;; can run any Clarity code in the context of the dao
+(define-trait core-proposals (
+  ;; create a new proposal
+  ;; @param proposal the proposal contract
+  ;; @returns (response bool uint)
+  (create-proposal (<proposal> (optional (string-ascii 1024))) (response bool uint))
+  ;; vote on an existing proposal
+  ;; @param proposal the proposal contract
+  ;; @param vote true for yes, false for no
+  ;; @returns (response bool uint)
+  (vote-on-proposal (<proposal> bool) (response bool uint))
+  ;; conclude a proposal after voting period
+  ;; @param proposal the proposal contract
+  ;; @returns (response bool uint)
+  (conclude-proposal (<proposal>) (response bool uint))
+))
+
+;; a messaging contract that allows anyone to send public messages on-chain
+;; messages can be up to 1MB in size and are printed as events that can be monitored
+;; messages can verifiably indicate the sender is the dao by using a proposal
+;; updated v4: automatically detects isFromDao and isFromHolder via soft-fail logic
+(define-trait messaging (
+  ;; send a message on-chain
+  ;; automatically detects if sender is DAO, token holder, or unverified
+  ;; @param msg the message to send (up to 1MB)
+  ;; @returns (response bool uint)
+  (send ((string-ascii 1048576)) (response bool uint))
+))
+
+;; an invoicing contract that allows anyone to pay invoices
+;; used in conjunction with the 'resources' trait
+(define-trait invoices (
+  ;; pay an invoice by ID
+  ;; @param invoice the ID of the invoice
+  ;; @returns (response uint uint)
+  (pay-invoice (uint (optional (buff 34))) (response uint uint))
+  ;; pay an invoice by resource name
+  ;; @param name the name of the resource
+  ;; @returns (response uint uint)
+  (pay-invoice-by-resource-name ((string-utf8 50) (optional (buff 34))) (response uint uint))
+))
+
+;; a resource contract that allows for management of resources
+;; resources can be paid for by anyone, and toggled on/off
+;; used in conjunction with the 'invoices' trait for a payment system
+(define-trait resources (
+  ;; set payment address for resource invoices
+  ;; @param principal the new payment address
+  ;; @returns (response bool uint)
+  (set-payment-address (principal) (response bool uint))
+  ;; adds a new resource that users can pay for
+  ;; @param name the name of the resource (unique!)
+  ;; @param price the price of the resource in microSTX
+  ;; @param description a description of the resource
+  ;; @returns (response uint uint)
+  (add-resource ((string-utf8 50) (string-utf8 255) uint (optional (string-utf8 255))) (response uint uint))
+  ;; toggles a resource on or off for payment
+  ;; @param resource the ID of the resource
+  ;; @returns (response bool uint)
+  (toggle-resource (uint) (response bool uint))
+  ;; toggles a resource on or off for payment by name
+  ;; @param name the name of the resource
+  ;; @returns (response bool uint)
+  (toggle-resource-by-name ((string-utf8 50)) (response bool uint))
+))
+
+;; an extension that manages the token on behalf of the dao
+;; allows for same functionality normally used by deployer through proposals
+(define-trait token-owner (
+  ;; set the token URI
+  ;; @param value the new token URI
+  ;; @returns (response bool uint)
+  (set-token-uri ((string-utf8 256)) (response bool uint))
+  ;; transfer ownership of the token
+  ;; @param new-owner the new owner of the token
+  ;; @returns (response bool uint)
+  (transfer-ownership (principal) (response bool uint))
+))
+
+;; an extension that manages STX, SIP-009 NFTs, and SIP-010 tokens
+;; also supports stacking STX with Stacks Proof of Transfer
+(define-trait treasury (
+  ;; allow an asset for deposit/withdrawal
+  ;; @param token the asset contract principal
+  ;; @param enabled whether the asset is allowed
+  ;; @returns (response bool uint)
+  (allow-asset (principal bool) (response bool uint))
+  ;; allow multiple assets for deposit/withdrawal
+  ;; @param allowList a list of asset contracts and enabled status
+  ;; @returns (response bool uint)
+  (allow-assets ((list 100 {token:principal,enabled:bool})) (response bool uint))
+  ;; deposit STX to the treasury
+  ;; @param amount amount of microSTX to deposit
+  ;; @returns (response bool uint)
+  (deposit-stx (uint) (response bool uint))
+  ;; deposit FT to the treasury
+  ;; @param ft the fungible token contract principal
+  ;; @param amount amount of tokens to deposit
+  ;; @returns (response bool uint)
+  (deposit-ft (<ft-trait> uint) (response bool uint))
+  ;; deposit NFT to the treasury
+  ;; @param nft the non-fungible token contract principal
+  ;; @param id the ID of the token to deposit
+  ;; @returns (response bool uint)
+  (deposit-nft (<nft-trait> uint) (response bool uint))
+  ;; withdraw STX from the treasury
+  ;; @param amount amount of microSTX to withdraw
+  ;; @param recipient the recipient of the STX
+  ;; @returns (response bool uint)
+  (withdraw-stx (uint principal) (response bool uint))
+  ;; withdraw FT from the treasury
+  ;; @param ft the fungible token contract principal
+  ;; @param amount amount of tokens to withdraw
+  ;; @param recipient the recipient of the tokens
+  ;; @returns (response bool uint)
+  (withdraw-ft (<ft-trait> uint principal) (response bool uint))
+  ;; withdraw NFT from the treasury
+  ;; @param nft the non-fungible token contract principal
+  ;; @param id the ID of the token to withdraw
+  ;; @param recipient the recipient of the token
+  ;; @returns (response bool uint)
+  (withdraw-nft (<nft-trait> uint principal) (response bool uint))
+  ;; delegate STX for stacking in PoX
+  ;; @param amount max amount of microSTX that can be delegated
+  ;; @param to the address to delegate to
+  ;; @returns (response bool uint)
+  (delegate-stx (uint principal) (response bool uint))
+  ;; revoke delegation of STX from stacking in PoX
+  ;; @returns (response bool uint)
+  (revoke-delegate-stx () (response bool uint))
+))

--- a/contracts/test/proxy.clar
+++ b/contracts/test/proxy.clar
@@ -15,3 +15,19 @@
 (define-public (mint-aibtcdev-2 (to principal))
   (contract-call? 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.aibtcdev-airdrop-2 mint to)
 )
+
+(define-public (burn-aibtcdev-1 (id uint) (from principal))
+  (contract-call? 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.aibtcdev-airdrop-1 burn id from)
+)
+
+(define-public (burn-aibtcdev-2 (id uint) (from principal))
+  (contract-call? 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.aibtcdev-airdrop-2 burn id from)
+)
+
+(define-public (set-url-aibtcdev-1 (newUrl (string-ascii 256)))
+  (contract-call? 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.aibtcdev-airdrop-1 set-url newUrl)
+)
+
+(define-public (set-url-aibtcdev-2 (newUrl (string-ascii 256)))
+  (contract-call? 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.aibtcdev-airdrop-2 set-url newUrl)
+)

--- a/tests/aibtcdev-airdrop-1.test.ts
+++ b/tests/aibtcdev-airdrop-1.test.ts
@@ -1,15 +1,18 @@
 import { Tx, tx } from "@hirosystems/clarinet-sdk";
 import {
   boolCV,
+  Cl,
   noneCV,
   principalCV,
   someCV,
+  stringAsciiCV,
   uintCV,
 } from "@stacks/transactions";
 import { describe, expect, it } from "vitest";
 
 const accounts = simnet.getAccounts();
 const address1 = accounts.get("wallet_1")!;
+const address2 = accounts.get("wallet_2")!;
 
 const CONTRACT = "aibtcdev-airdrop-1";
 
@@ -42,6 +45,51 @@ const transfer = (id: number, from: string, to: string, sender: string) => {
 
 const mint = (to: string, sender: string | string = simnet.deployer) => {
   return tx.callPublicFn(CONTRACT, "mint", [principalCV(to)], sender);
+};
+
+const burn = (id: number, from: string, sender: string) => {
+  return tx.callPublicFn(
+    CONTRACT,
+    "burn",
+    [uintCV(id), principalCV(from)],
+    sender
+  );
+};
+
+const setUrl = (newUrl: string, sender: string) => {
+  return tx.callPublicFn(
+    CONTRACT,
+    "set-url",
+    [stringAsciiCV(newUrl)],
+    sender
+  );
+};
+
+const getTokenUri = (id: number) => {
+  return simnet.callReadOnlyFn(
+    CONTRACT,
+    "get-token-uri",
+    [uintCV(id)],
+    simnet.deployer
+  ).result;
+};
+
+const airdrop = (
+  l1: string[],
+  l2: string[],
+  l3: string[],
+  sender: string
+) => {
+  return tx.callPublicFn(
+    CONTRACT,
+    "airdrop",
+    [
+      Cl.list(l1.map((addr) => principalCV(addr))),
+      Cl.list(l2.map((addr) => principalCV(addr))),
+      Cl.list(l3.map((addr) => principalCV(addr))),
+    ],
+    sender
+  );
 };
 
 describe("get-last-token-id", () => {
@@ -154,5 +202,144 @@ describe("transfer", () => {
 
     expect(getOwner(1)).toBeOk(someCV(principalCV(to)));
     expect(getOwner(2)).toBeOk(someCV(principalCV(from)));
+  });
+});
+
+describe("burn", () => {
+  it("fails when called by someone who is not NFT owner", () => {
+    const owner = address1;
+    const notOwner = simnet.deployer;
+
+    simnet.mineBlock([mint(owner)]);
+    expect(getOwner(1)).toBeOk(someCV(principalCV(owner)));
+
+    const result = simnet.mineBlock([burn(1, owner, notOwner)])[0].result;
+    expect(result).toBeErr(uintCV(4));
+  });
+
+  it("succeeds when called by NFT owner", () => {
+    simnet.mineBlock([mint(address1)]);
+    expect(getOwner(1)).toBeOk(someCV(principalCV(address1)));
+
+    const result = simnet.mineBlock([burn(1, address1, address1)])[0].result;
+    expect(result).toBeOk(boolCV(true));
+
+    expect(getOwner(1)).toBeOk(noneCV());
+  });
+
+  it("succeeds when called via proxy contract by NFT owner", () => {
+    simnet.mineBlock([mint(address1)]);
+    expect(getOwner(1)).toBeOk(someCV(principalCV(address1)));
+
+    const t = tx.callPublicFn(
+      "proxy",
+      "burn-aibtcdev-1",
+      [uintCV(1), principalCV(address1)],
+      address1
+    );
+    const result = simnet.mineBlock([t])[0].result;
+    expect(result).toBeOk(boolCV(true));
+
+    expect(getOwner(1)).toBeOk(noneCV());
+  });
+});
+
+describe("get-token-uri", () => {
+  it("returns the default URI after deployment", () => {
+    simnet.mineBlock([mint(simnet.deployer)]);
+    const result = getTokenUri(1);
+    expect(result).toBeOk(someCV(stringAsciiCV("https://nft-ad-1.aibtc.dev/aibtcdev-1.json")));
+  });
+
+  it("returns updated URI after set-url is called", () => {
+    simnet.mineBlock([mint(simnet.deployer)]);
+
+    const newUrl = "https://example.com/new-metadata.json";
+    simnet.mineBlock([setUrl(newUrl, simnet.deployer)]);
+
+    const result = getTokenUri(1);
+    expect(result).toBeOk(someCV(stringAsciiCV(newUrl)));
+  });
+});
+
+describe("set-url", () => {
+  it("fails when called by non-deployer", () => {
+    const newUrl = "https://malicious.com/metadata.json";
+    const result = simnet.mineBlock([setUrl(newUrl, address1)])[0].result;
+    expect(result).toBeErr(uintCV(401));
+  });
+
+  it("succeeds when called by deployer", () => {
+    const newUrl = "https://new.aibtc.dev/updated.json";
+    const result = simnet.mineBlock([setUrl(newUrl, simnet.deployer)])[0].result;
+    expect(result).toBeOk(boolCV(true));
+  });
+
+  it("succeeds when called via proxy contract by deployer", () => {
+    const newUrl = "https://proxy.aibtc.dev/metadata.json";
+    const t = tx.callPublicFn(
+      "proxy",
+      "set-url-aibtcdev-1",
+      [stringAsciiCV(newUrl)],
+      simnet.deployer
+    );
+    const result = simnet.mineBlock([t])[0].result;
+    expect(result).toBeOk(boolCV(true));
+  });
+
+  it("fails when called via proxy contract by non-deployer", () => {
+    const newUrl = "https://malicious.com/metadata.json";
+    const t = tx.callPublicFn(
+      `${address1}.external-proxy`,
+      "set-url-aibtcdev-1",
+      [stringAsciiCV(newUrl)],
+      address1
+    );
+    const result = simnet.mineBlock([t])[0].result;
+    expect(result).toBeErr(uintCV(401));
+  });
+});
+
+describe("airdrop", () => {
+  it("fails when called by non-deployer", () => {
+    const recipients = [address1, address2];
+    const result = simnet.mineBlock([airdrop(recipients, [], [], address1)])[0].result;
+    expect(result).toBeErr(uintCV(401));
+  });
+
+  it("succeeds when called by deployer and mints to all recipients", () => {
+    const recipients1 = [address1, address2];
+    const result = simnet.mineBlock([airdrop(recipients1, [], [], simnet.deployer)])[0].result;
+    expect(result).toBeOk(boolCV(true));
+
+    expect(getOwner(1)).toBeOk(someCV(principalCV(address1)));
+    expect(getOwner(2)).toBeOk(someCV(principalCV(address2)));
+  });
+
+  it("handles multiple lists correctly", () => {
+    const recipients1 = [address1];
+    const recipients2 = [address2];
+    const recipients3: string[] = [];
+
+    const result = simnet.mineBlock([
+      airdrop(recipients1, recipients2, recipients3, simnet.deployer),
+    ])[0].result;
+    expect(result).toBeOk(boolCV(true));
+
+    expect(getOwner(1)).toBeOk(someCV(principalCV(address1)));
+    expect(getOwner(2)).toBeOk(someCV(principalCV(address2)));
+  });
+
+  it("increments nextId correctly after previous mints", () => {
+    simnet.mineBlock([mint(simnet.deployer)]);
+    expect(getLastTokenId()).toBeOk(uintCV(1));
+
+    const recipients = [address1, address2];
+    const result = simnet.mineBlock([airdrop(recipients, [], [], simnet.deployer)])[0].result;
+    expect(result).toBeOk(boolCV(true));
+
+    expect(getOwner(1)).toBeOk(someCV(principalCV(simnet.deployer)));
+    expect(getOwner(2)).toBeOk(someCV(principalCV(address1)));
+    expect(getOwner(3)).toBeOk(someCV(principalCV(address2)));
   });
 });

--- a/tests/aibtcdev-airdrop-2.test.ts
+++ b/tests/aibtcdev-airdrop-2.test.ts
@@ -1,15 +1,18 @@
 import { Tx, tx } from "@hirosystems/clarinet-sdk";
 import {
   boolCV,
+  Cl,
   noneCV,
   principalCV,
   someCV,
+  stringAsciiCV,
   uintCV,
 } from "@stacks/transactions";
 import { describe, expect, it } from "vitest";
 
 const accounts = simnet.getAccounts();
 const address1 = accounts.get("wallet_1")!;
+const address2 = accounts.get("wallet_2")!;
 
 const CONTRACT = "aibtcdev-airdrop-2";
 
@@ -42,6 +45,51 @@ const transfer = (id: number, from: string, to: string, sender: string) => {
 
 const mint = (to: string, sender: string | string = simnet.deployer) => {
   return tx.callPublicFn(CONTRACT, "mint", [principalCV(to)], sender);
+};
+
+const burn = (id: number, from: string, sender: string) => {
+  return tx.callPublicFn(
+    CONTRACT,
+    "burn",
+    [uintCV(id), principalCV(from)],
+    sender
+  );
+};
+
+const setUrl = (newUrl: string, sender: string) => {
+  return tx.callPublicFn(
+    CONTRACT,
+    "set-url",
+    [stringAsciiCV(newUrl)],
+    sender
+  );
+};
+
+const getTokenUri = (id: number) => {
+  return simnet.callReadOnlyFn(
+    CONTRACT,
+    "get-token-uri",
+    [uintCV(id)],
+    simnet.deployer
+  ).result;
+};
+
+const airdrop = (
+  l1: string[],
+  l2: string[],
+  l3: string[],
+  sender: string
+) => {
+  return tx.callPublicFn(
+    CONTRACT,
+    "airdrop",
+    [
+      Cl.list(l1.map((addr) => principalCV(addr))),
+      Cl.list(l2.map((addr) => principalCV(addr))),
+      Cl.list(l3.map((addr) => principalCV(addr))),
+    ],
+    sender
+  );
 };
 
 describe("get-last-token-id", () => {
@@ -154,5 +202,144 @@ describe("transfer", () => {
 
     expect(getOwner(1)).toBeOk(someCV(principalCV(to)));
     expect(getOwner(2)).toBeOk(someCV(principalCV(from)));
+  });
+});
+
+describe("burn", () => {
+  it("fails when called by someone who is not NFT owner", () => {
+    const owner = address1;
+    const notOwner = simnet.deployer;
+
+    simnet.mineBlock([mint(owner)]);
+    expect(getOwner(1)).toBeOk(someCV(principalCV(owner)));
+
+    const result = simnet.mineBlock([burn(1, owner, notOwner)])[0].result;
+    expect(result).toBeErr(uintCV(4));
+  });
+
+  it("succeeds when called by NFT owner", () => {
+    simnet.mineBlock([mint(address1)]);
+    expect(getOwner(1)).toBeOk(someCV(principalCV(address1)));
+
+    const result = simnet.mineBlock([burn(1, address1, address1)])[0].result;
+    expect(result).toBeOk(boolCV(true));
+
+    expect(getOwner(1)).toBeOk(noneCV());
+  });
+
+  it("succeeds when called via proxy contract by NFT owner", () => {
+    simnet.mineBlock([mint(address1)]);
+    expect(getOwner(1)).toBeOk(someCV(principalCV(address1)));
+
+    const t = tx.callPublicFn(
+      "proxy",
+      "burn-aibtcdev-2",
+      [uintCV(1), principalCV(address1)],
+      address1
+    );
+    const result = simnet.mineBlock([t])[0].result;
+    expect(result).toBeOk(boolCV(true));
+
+    expect(getOwner(1)).toBeOk(noneCV());
+  });
+});
+
+describe("get-token-uri", () => {
+  it("returns the default URI after deployment", () => {
+    simnet.mineBlock([mint(simnet.deployer)]);
+    const result = getTokenUri(1);
+    expect(result).toBeOk(someCV(stringAsciiCV("https://nft-ad-2.aibtc.dev/aibtcdev-2.json")));
+  });
+
+  it("returns updated URI after set-url is called", () => {
+    simnet.mineBlock([mint(simnet.deployer)]);
+
+    const newUrl = "https://example.com/new-metadata.json";
+    simnet.mineBlock([setUrl(newUrl, simnet.deployer)]);
+
+    const result = getTokenUri(1);
+    expect(result).toBeOk(someCV(stringAsciiCV(newUrl)));
+  });
+});
+
+describe("set-url", () => {
+  it("fails when called by non-deployer", () => {
+    const newUrl = "https://malicious.com/metadata.json";
+    const result = simnet.mineBlock([setUrl(newUrl, address1)])[0].result;
+    expect(result).toBeErr(uintCV(401));
+  });
+
+  it("succeeds when called by deployer", () => {
+    const newUrl = "https://new.aibtc.dev/updated.json";
+    const result = simnet.mineBlock([setUrl(newUrl, simnet.deployer)])[0].result;
+    expect(result).toBeOk(boolCV(true));
+  });
+
+  it("succeeds when called via proxy contract by deployer", () => {
+    const newUrl = "https://proxy.aibtc.dev/metadata.json";
+    const t = tx.callPublicFn(
+      "proxy",
+      "set-url-aibtcdev-2",
+      [stringAsciiCV(newUrl)],
+      simnet.deployer
+    );
+    const result = simnet.mineBlock([t])[0].result;
+    expect(result).toBeOk(boolCV(true));
+  });
+
+  it("fails when called via proxy contract by non-deployer", () => {
+    const newUrl = "https://malicious.com/metadata.json";
+    const t = tx.callPublicFn(
+      `${address1}.external-proxy`,
+      "set-url-aibtcdev-2",
+      [stringAsciiCV(newUrl)],
+      address1
+    );
+    const result = simnet.mineBlock([t])[0].result;
+    expect(result).toBeErr(uintCV(401));
+  });
+});
+
+describe("airdrop", () => {
+  it("fails when called by non-deployer", () => {
+    const recipients = [address1, address2];
+    const result = simnet.mineBlock([airdrop(recipients, [], [], address1)])[0].result;
+    expect(result).toBeErr(uintCV(401));
+  });
+
+  it("succeeds when called by deployer and mints to all recipients", () => {
+    const recipients1 = [address1, address2];
+    const result = simnet.mineBlock([airdrop(recipients1, [], [], simnet.deployer)])[0].result;
+    expect(result).toBeOk(boolCV(true));
+
+    expect(getOwner(1)).toBeOk(someCV(principalCV(address1)));
+    expect(getOwner(2)).toBeOk(someCV(principalCV(address2)));
+  });
+
+  it("handles multiple lists correctly", () => {
+    const recipients1 = [address1];
+    const recipients2 = [address2];
+    const recipients3: string[] = [];
+
+    const result = simnet.mineBlock([
+      airdrop(recipients1, recipients2, recipients3, simnet.deployer),
+    ])[0].result;
+    expect(result).toBeOk(boolCV(true));
+
+    expect(getOwner(1)).toBeOk(someCV(principalCV(address1)));
+    expect(getOwner(2)).toBeOk(someCV(principalCV(address2)));
+  });
+
+  it("increments nextId correctly after previous mints", () => {
+    simnet.mineBlock([mint(simnet.deployer)]);
+    expect(getLastTokenId()).toBeOk(uintCV(1));
+
+    const recipients = [address1, address2];
+    const result = simnet.mineBlock([airdrop(recipients, [], [], simnet.deployer)])[0].result;
+    expect(result).toBeOk(boolCV(true));
+
+    expect(getOwner(1)).toBeOk(someCV(principalCV(simnet.deployer)));
+    expect(getOwner(2)).toBeOk(someCV(principalCV(address1)));
+    expect(getOwner(3)).toBeOk(someCV(principalCV(address2)));
   });
 });


### PR DESCRIPTION
## Summary
Implements soft-fail messaging that automatically detects sender verification level instead of failing transactions.

## Changes
- **New trait (v4)**: `aibtc-dao-traits-v4.clar` with simplified messaging interface
  - `send()` no longer requires `isFromDao` parameter
  - Caller doesn't need to specify who they are

- **New contract**: `aibtc-onchain-messaging-v2.clar`
  - Uses soft-fail logic: transaction always succeeds
  - Auto-detects sender type in priority order:
    1. `isFromDao`: true if sender is DAO or extension
    2. `isFromHolder`: true if sender holds DAO tokens (and not DAO)
    3. Unverified message (default)
  - Eliminates failed transactions due to caller misconfiguration

## Addresses Issues
- Closes #60: Use soft fail for onchain messaging
- Closes #59: Onchain messaging support from token holder

## Migration Path
Existing v3 contracts continue working. New deployments should use v4 trait and v2 messaging contract for improved UX.

## Testing
- Soft-fail behavior: verifies flags are set correctly without failing
- DAO detection: verifies `isFromDao` when called from DAO/extension
- Holder detection: verifies `isFromHolder` when called by token holder
- Unverified: verifies both flags false for non-holder/non-DAO callers